### PR TITLE
feat: add viewport support in cappa/storybook

### DIFF
--- a/examples/storybook/stories/Button.stories.ts
+++ b/examples/storybook/stories/Button.stories.ts
@@ -38,8 +38,8 @@ export const Primary: Story = {
   parameters: {
     cappa: {
       viewport: {
-        width: 100,
-        height: 100,
+        width: 200,
+        height: 200,
       },
     },
   },

--- a/packages/core/src/compare.test.ts
+++ b/packages/core/src/compare.test.ts
@@ -307,6 +307,7 @@ describe("compare", () => {
         totalPixels: 100,
         percentDifference: 0,
         passed: true,
+        differentSizes: false,
         // diffBuffer is undefined
       };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,6 +83,7 @@ export type ScreenshotOptions = {
   skip?: boolean;
   mask?: Locator[];
   omitBackground?: boolean;
+  viewport?: { width: number; height: number };
 };
 
 export interface Screenshot {

--- a/packages/plugins/plugin-storybook/README.md
+++ b/packages/plugins/plugin-storybook/README.md
@@ -52,6 +52,7 @@ Cappa uses a storybook addon that allows you to pass options from storybook into
 | fullPage | Whether to take a full page screenshot          | true            |
 | mask     | An array of selectors to mask in the screenshot | []              |
 | omitBackground | Whether to omit the background in the screenshot | false |
+| viewport | The viewport to use for the screenshot | null (use default viewport) |
 
 #### Example
 
@@ -63,6 +64,7 @@ export const Primary: Story = {
       delay: 1000,
       fullPage: false,
       mask: ["#my-element", ".my-class"],
+      viewport: { width: 1920, height: 1080 },
     },
   },
 };

--- a/packages/plugins/plugin-storybook/src/cappa/plugin.ts
+++ b/packages/plugins/plugin-storybook/src/cappa/plugin.ts
@@ -168,6 +168,13 @@ export const cappaPluginStorybook: Plugin<StorybookPluginOptions> = (
               logger.debug("Taking screenshot with options", options);
             }
 
+            // setting viewport early because of timing
+            if (options.viewport) {
+              await page.setViewportSize(options.viewport);
+            } else {
+              await page.setViewportSize(screenshotTool.viewport); // reset
+            }
+
             await freezeUI(page);
             await waitForVisualIdle(page);
 


### PR DESCRIPTION
- Updated the ScreenshotTool class to include viewport options for screenshot capturing.
- Added error handling in the compareImages function to manage different image sizes and log errors.
- Introduced a new method to create a placeholder image for different sizes.
- Updated related types and documentation to reflect the new viewport feature.