### PR TITLE
feat: add keyboard shortcuts to screenshot review page

### DIFF
--- a/.changeset/keyboard-shortcuts-review.md
+++ b/.changeset/keyboard-shortcuts-review.md
@@ -1,0 +1,5 @@
+---
+"@cappa/server": minor
+---
+
+Add keyboard shortcuts to the screenshot review page: ArrowLeft / ArrowRight to navigate between screenshots and `a` to approve the current screenshot.

--- a/apps/docs/src/content/docs/cli.mdx
+++ b/apps/docs/src/content/docs/cli.mdx
@@ -36,6 +36,11 @@ The review UI supports **batch approval**: in grid or list view you can select m
 in one action. On category pages (e.g. New or Changed), **Approve all in category** approves every
 screenshot in the current view at once.
 
+When inspecting a single screenshot, the following keyboard shortcuts are available:
+
+- <kbd>←</kbd> / <kbd>→</kbd>: navigate to the previous or next screenshot.
+- <kbd>A</kbd>: approve the current screenshot.
+
 ## `cappa approve`
 
 Promotes the currently reviewed screenshots to the baseline. This command is typically run after a

--- a/apps/web/src/components/ScreenshotViewer/ScreenshotViewer.tsx
+++ b/apps/web/src/components/ScreenshotViewer/ScreenshotViewer.tsx
@@ -19,8 +19,8 @@ import {
   SplitSquareHorizontal,
   ToggleRight,
 } from "lucide-react";
-import { useState } from "react";
-import { Link } from "react-router";
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router";
 import { CategoryBadge } from "../CategoryBadge";
 import { Diff } from "./components/Diff";
 import { Overlay } from "./components/Overlay";
@@ -51,6 +51,7 @@ export function ScreenshotComparison({
     getInitialViewMode(),
   );
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const handleViewModeChange = (nextMode: ViewMode) => {
     setViewMode(nextMode);
@@ -73,6 +74,36 @@ export function ScreenshotComparison({
       });
     },
   });
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target?.isContentEditable) return;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
+      if (event.key === "ArrowLeft" && screenshot.prev) {
+        event.preventDefault();
+        navigate(`/screenshots/${screenshot.prev}`);
+      } else if (event.key === "ArrowRight" && screenshot.next) {
+        event.preventDefault();
+        navigate(`/screenshots/${screenshot.next}`);
+      } else if (event.key === "a" && !screenshot.approved) {
+        event.preventDefault();
+        approveScreenshot(true);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [
+    screenshot.prev,
+    screenshot.next,
+    screenshot.approved,
+    navigate,
+    approveScreenshot,
+  ]);
 
   return (
     <div className="flex flex-col h-full bg-background">

--- a/apps/web/src/pages/Screenshot.test.tsx
+++ b/apps/web/src/pages/Screenshot.test.tsx
@@ -1,4 +1,7 @@
+import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { userEvent } from "vitest/browser";
+import { server } from "../test/setup";
 import { renderPageWithRoute } from "../test/utils";
 import { Screenshot } from "./Screenshot";
 
@@ -83,6 +86,73 @@ describe("Screenshot page", () => {
     await expect
       .element(screen.getByRole("heading", { name: "Visual Differences" }))
       .toBeVisible();
+  });
+
+  it("navigates to the next screenshot when ArrowRight is pressed", async () => {
+    const screen = await renderPageWithRoute(
+      "/screenshots/:id",
+      "/screenshots/3",
+      <Screenshot />,
+    );
+
+    await expect
+      .element(screen.getByRole("heading", { name: "3" }))
+      .toBeVisible();
+
+    await userEvent.keyboard("{ArrowRight}");
+
+    await expect
+      .element(screen.getByRole("heading", { name: "4" }))
+      .toBeVisible();
+  });
+
+  it("navigates to the previous screenshot when ArrowLeft is pressed", async () => {
+    const screen = await renderPageWithRoute(
+      "/screenshots/:id",
+      "/screenshots/3",
+      <Screenshot />,
+    );
+
+    await expect
+      .element(screen.getByRole("heading", { name: "3" }))
+      .toBeVisible();
+
+    await userEvent.keyboard("{ArrowLeft}");
+
+    await expect
+      .element(screen.getByRole("heading", { name: "2" }))
+      .toBeVisible();
+  });
+
+  it("approves the screenshot when the 'a' key is pressed", async () => {
+    let capturedBody: unknown;
+
+    server.use(
+      http.patch("/api/screenshots/:id", async ({ request, params }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          name: params.id,
+          id: params.id,
+          category: "new",
+          actualPath: "/images/4a.png",
+          approved: true,
+        });
+      }),
+    );
+
+    const screen = await renderPageWithRoute(
+      "/screenshots/:id",
+      "/screenshots/3",
+      <Screenshot />,
+    );
+
+    await expect
+      .element(screen.getByRole("heading", { name: "3" }))
+      .toBeVisible();
+
+    await userEvent.keyboard("a");
+
+    await expect.poll(() => capturedBody).toEqual({ approved: true });
   });
 
   it("initializes changed screenshots from persisted view mode", async () => {

--- a/apps/web/src/pages/Screenshot.test.tsx
+++ b/apps/web/src/pages/Screenshot.test.tsx
@@ -1,9 +1,14 @@
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { userEvent } from "vitest/browser";
 import { server } from "../test/setup";
 import { renderPageWithRoute } from "../test/utils";
 import { Screenshot } from "./Screenshot";
+
+function pressKey(key: string) {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }),
+  );
+}
 
 describe("Screenshot page", () => {
   beforeEach(() => {
@@ -99,7 +104,7 @@ describe("Screenshot page", () => {
       .element(screen.getByRole("heading", { name: "3" }))
       .toBeVisible();
 
-    await userEvent.keyboard("{ArrowRight}");
+    pressKey("ArrowRight");
 
     await expect
       .element(screen.getByRole("heading", { name: "4" }))
@@ -117,7 +122,7 @@ describe("Screenshot page", () => {
       .element(screen.getByRole("heading", { name: "3" }))
       .toBeVisible();
 
-    await userEvent.keyboard("{ArrowLeft}");
+    pressKey("ArrowLeft");
 
     await expect
       .element(screen.getByRole("heading", { name: "2" }))
@@ -150,7 +155,7 @@ describe("Screenshot page", () => {
       .element(screen.getByRole("heading", { name: "3" }))
       .toBeVisible();
 
-    await userEvent.keyboard("a");
+    pressKey("a");
 
     await expect.poll(() => capturedBody).toEqual({ approved: true });
   });


### PR DESCRIPTION
## Summary
Add keyboard shortcuts to the screenshot review page for improved navigation and approval workflow. Users can now use arrow keys to navigate between screenshots and the 'a' key to approve the current screenshot.

## Changes
- **ScreenshotViewer component**: Added `useEffect` hook to listen for keyboard events with smart filtering (ignores modifier keys, content-editable elements, and form inputs)
  - `ArrowLeft`: Navigate to previous screenshot (if available)
  - `ArrowRight`: Navigate to next screenshot (if available)
  - `a`: Approve current screenshot (if not already approved)
- **Tests**: Added three new test cases covering all keyboard shortcut scenarios
  - Navigation via ArrowRight
  - Navigation via ArrowLeft
  - Approval via 'a' key with API verification
- **Documentation**: Updated CLI docs to document the new keyboard shortcuts with visual kbd elements
- **Changeset**: Added entry documenting the feature as a minor version bump for `@cappa/server`

## Implementation Details
- Keyboard handler respects common UX patterns: ignores events when modifier keys are held, when focus is on form inputs, or when editing content
- Uses `useNavigate` from react-router to handle screenshot navigation
- Properly cleans up event listener on component unmount
- Dependencies array includes all necessary values to ensure handler has access to current screenshot state

https://claude.ai/code/session_01KBiQotWVr35kYHJWVUN3C3