### PR TITLE
Adding port configuration for review UI

### DIFF
--- a/.changeset/giant-yaks-pick.md
+++ b/.changeset/giant-yaks-pick.md
@@ -1,0 +1,6 @@
+---
+"@cappa/cli": minor
+"@cappa/core": minor
+---
+
+Adding a configuration option to override the default port 3000 for the review UI.

--- a/apps/docs/src/content/docs/configuration.mdx
+++ b/apps/docs/src/content/docs/configuration.mdx
@@ -185,6 +185,21 @@ export default defineConfig({
 });
 ```
 
+### review.port
+
+- **type**: `number`
+- **default**: `3000`
+
+Port for the review UI server. Set to a different value if port 3000 is already in use.
+
+```ts
+export default defineConfig({
+  review: {
+    port: 4000,
+  },
+});
+```
+
 ## onFail
 
 - **type**: `(screenshots: FailedScreenshot[]) => void | Promise<void>`

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -43,6 +43,6 @@ export const review = async () => {
     diff: config.diff,
   });
 
-  logger.success("Review UI available at http://localhost:3000");
-  await server.listen({ port: 3000 });
+  logger.success(`Review UI available at http://localhost:${config.review.port}`);
+  await server.listen({ port: config.review.port });
 };

--- a/packages/cli/src/features/config/getConfig.test.ts
+++ b/packages/cli/src/features/config/getConfig.test.ts
@@ -44,7 +44,7 @@ test("return Config when config is set with defineConfig", async () => {
       fullPage: true,
       viewport: { width: 1920, height: 1080 },
     },
-    review: { theme: "light" },
+    review: { theme: "light", port: 3000 },
   });
 });
 
@@ -104,6 +104,22 @@ test("respects review.theme override", async () => {
   expect(cappaUserConfig.review.theme).toBe("dark");
 });
 
+test("respects review.port override", async () => {
+  const config: ConfigResult["config"] = defineConfig({
+    outputDir: "./screenshots",
+    retries: 2,
+    plugins: [],
+    review: { port: 5000 },
+  });
+
+  const cappaUserConfig = await getConfig({
+    config,
+    filepath: "./cappa.config.ts",
+  });
+
+  expect(cappaUserConfig.review.port).toBe(5000);
+});
+
 test("respects logConsoleEvents override", async () => {
   const config: ConfigResult["config"] = defineConfig({
     outputDir: "./screenshots",
@@ -156,7 +172,7 @@ test("return Config when config is a function", async () => {
       fullPage: true,
       viewport: { width: 1920, height: 1080 },
     },
-    review: { theme: "light" },
+    review: { theme: "light", port: 3000 },
   });
 });
 
@@ -193,7 +209,7 @@ test("return Config when config is a promise", async () => {
       fullPage: true,
       viewport: { width: 1920, height: 1080 },
     },
-    review: { theme: "light" },
+    review: { theme: "light", port: 3000 },
   });
 });
 
@@ -242,7 +258,7 @@ test("passes environment variables to config functions", async () => {
       fullPage: true,
       viewport: { width: 1920, height: 1080 },
     },
-    review: { theme: "light" },
+    review: { theme: "light", port: 3000 },
   });
 
   if (originalNodeEnv === undefined) {

--- a/packages/cli/src/features/config/getConfig.ts
+++ b/packages/cli/src/features/config/getConfig.ts
@@ -79,6 +79,7 @@ export async function getConfig(
     },
     review: {
       theme: userConfig.review?.theme ?? "light",
+      port: userConfig.review?.port ?? 3000,
     },
     connectionTimeout: userConfig.connectionTimeout ?? 20000,
   };

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -608,7 +608,7 @@ describe("cappa CLI", () => {
         maxDiffPixels: 0,
         maxDiffPercentage: 0,
       },
-      review: { theme: "light" },
+      review: { theme: "light", port: 4000 },
     });
 
     globMock.mockImplementation((pattern: string) => {
@@ -653,9 +653,9 @@ describe("cappa CLI", () => {
     });
 
     expect(serverInstances).toHaveLength(1);
-    expect(serverInstances[0]?.listen).toHaveBeenCalledWith({ port: 3000 });
+    expect(serverInstances[0]?.listen).toHaveBeenCalledWith({ port: 4000 });
     expect(loggerInstance.success).toHaveBeenCalledWith(
-      "Review UI available at http://localhost:3000",
+      "Review UI available at http://localhost:4000",
     );
   });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -174,6 +174,11 @@ export type UserConfig = {
      * - `'dark'`: Dark mode
      */
     theme?: "light" | "dark";
+    /**
+     * Port for the review UI server.
+     * @default 3000
+     */
+    port?: number;
   };
 };
 


### PR DESCRIPTION
I noticed that the port of the review UI was hardcoded and at least on my end port 3000 is a very regular port to be used, so I would like to have the ability to override the default port via the configuration.