### PR TITLE
fix(cli): forward diff.interpret through config normalization

### DIFF
--- a/.changeset/fix-interpret-config.md
+++ b/.changeset/fix-interpret-config.md
@@ -1,0 +1,12 @@
+---
+"@cappa/cli": patch
+---
+
+fix: pass through `diff.interpret` when normalizing the pixel diff config
+
+The CLI's config normalization rebuilt the pixel `diff` object from a fixed
+field whitelist that omitted `interpret`, so `diff: { interpret: true }` in
+`cappa.config.ts` was silently dropped before reaching the screenshot tool. As
+a result the interpretation pass never ran and no `diff/<name>.json` sidecars
+were written, so the CLI `status` output and the review UI never surfaced any
+interpretation. The flag is now forwarded correctly.

--- a/packages/cli/src/features/config/getConfig.test.ts
+++ b/packages/cli/src/features/config/getConfig.test.ts
@@ -37,6 +37,7 @@ test("return Config when config is set with defineConfig", async () => {
       fastBufferCheck: true,
       maxDiffPixels: 0,
       maxDiffPercentage: 0,
+      interpret: false,
     },
     plugins: [],
     onFail: undefined,
@@ -165,6 +166,7 @@ test("return Config when config is a function", async () => {
       fastBufferCheck: true,
       maxDiffPixels: 0,
       maxDiffPercentage: 0,
+      interpret: false,
     },
     plugins: [],
     onFail: undefined,
@@ -202,6 +204,7 @@ test("return Config when config is a promise", async () => {
       fastBufferCheck: true,
       maxDiffPixels: 0,
       maxDiffPercentage: 0,
+      interpret: false,
     },
     plugins: [],
     onFail: undefined,
@@ -251,6 +254,7 @@ test("passes environment variables to config functions", async () => {
       fastBufferCheck: true,
       maxDiffPixels: 0,
       maxDiffPercentage: 0,
+      interpret: false,
     },
     plugins: [],
     onFail: undefined,
@@ -299,6 +303,32 @@ test("keeps explicit pixel diff values from config", async () => {
     fastBufferCheck: false,
     maxDiffPixels: 5,
     maxDiffPercentage: 1,
+    interpret: false,
+  });
+});
+
+test("enables interpret when set in the pixel diff config", async () => {
+  const config: ConfigResult["config"] = defineConfig({
+    plugins: [],
+    diff: {
+      type: "pixel",
+      interpret: true,
+    },
+  });
+
+  const cappaUserConfig = await getConfig({
+    config,
+    filepath: "./cappa.config.ts",
+  });
+
+  expect(cappaUserConfig.diff).toEqual({
+    type: "pixel",
+    threshold: 0.1,
+    includeAA: false,
+    fastBufferCheck: true,
+    maxDiffPixels: 0,
+    maxDiffPercentage: 0,
+    interpret: true,
   });
 });
 

--- a/packages/cli/src/features/config/getConfig.ts
+++ b/packages/cli/src/features/config/getConfig.ts
@@ -51,6 +51,7 @@ export async function getConfig(
         fastBufferCheck: userConfig.diff?.fastBufferCheck ?? true,
         maxDiffPixels: userConfig.diff?.maxDiffPixels ?? 0,
         maxDiffPercentage: userConfig.diff?.maxDiffPercentage ?? 0,
+        interpret: userConfig.diff?.interpret ?? false,
       };
     }
 


### PR DESCRIPTION
getConfig rebuilt the pixel diff config from a fixed field whitelist that
omitted interpret, silently dropping diff.interpret from cappa.config.ts. The
interpretation pass never ran and no diff sidecars were written, so CLI status
and the review UI never surfaced interpretation. Forward the flag and add a
regression test.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VVPyCTw4kJSBxjd8MihhqY