### PR TITLE
Add progress feedback during screenshot capture

### DIFF
--- a/.changeset/capture-progress-feedback.md
+++ b/.changeset/capture-progress-feedback.md
@@ -1,0 +1,5 @@
+---
+"@cappa/cli": patch
+---
+
+Add info-level progress feedback during capture so users see `[N/total] captured <task>` as each screenshot completes, instead of silence until the plugin finishes.

--- a/packages/cli/src/commands/capture.test.ts
+++ b/packages/cli/src/commands/capture.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   didScreenshotFail,
   formatDuration,
+  formatProgress,
   getDeletedScreenshots,
   registerSignalHandlers,
 } from "./capture";
@@ -147,6 +148,24 @@ describe("registerSignalHandlers", () => {
 
     expect(mockClose).not.toHaveBeenCalled();
     expect(mockExit).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatProgress", () => {
+  it("formats a progress message with completed count, total, and task ID", () => {
+    expect(formatProgress(1, 480, "story-button")).toBe(
+      "[1/480] captured story-button",
+    );
+  });
+
+  it("formats correctly when completed equals total", () => {
+    expect(formatProgress(480, 480, "story-footer")).toBe(
+      "[480/480] captured story-footer",
+    );
+  });
+
+  it("handles a single-task run", () => {
+    expect(formatProgress(1, 1, "homepage")).toBe("[1/1] captured homepage");
   });
 });
 

--- a/packages/cli/src/commands/capture.ts
+++ b/packages/cli/src/commands/capture.ts
@@ -122,6 +122,14 @@ async function executeOnFailCallback(
   }
 }
 
+export function formatProgress(
+  completed: number,
+  total: number,
+  taskId: string,
+): string {
+  return `[${completed}/${total}] captured ${taskId}`;
+}
+
 export function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
   const minutes = Math.floor(seconds / 60);
@@ -312,6 +320,8 @@ const runCapture = async (options: CaptureOptions = {}): Promise<void> => {
         `Processing ${tasks.length} tasks with ${effectiveConcurrency} contexts in ${chunks.length} chunks`,
       );
 
+      let completedTasks = 0;
+
       const allResults = await Promise.all(
         chunks.map(async (chunk, chunkIndex) => {
           const page = screenshotTool.getPageFromPool(chunkIndex);
@@ -335,6 +345,9 @@ const runCapture = async (options: CaptureOptions = {}): Promise<void> => {
               context,
             );
             chunkResults.push({ result, task });
+
+            completedTasks++;
+            logger.info(formatProgress(completedTasks, tasks.length, task.id));
 
             if (didScreenshotFail(result)) {
               pluginHasFailure = true;


### PR DESCRIPTION
## Summary
Adds real-time progress feedback to the `capture` command so users see `[N/total] captured <task>` logged at info level as each screenshot completes, instead of silence until the plugin finishes.

## Changes
- **New `formatProgress` function** in `capture.ts` that formats a progress message with completed count, total count, and task ID
- **Progress tracking in `runCapture`** — increments a `completedTasks` counter after each task completes and logs the formatted progress message via `logger.info()`
- **Test coverage** — added three test cases for `formatProgress` covering typical, edge (1/1), and completion (N/N) scenarios

## Implementation Details
- The progress counter is incremented immediately after a task result is pushed to `chunkResults`, before failure handling, ensuring accurate progress reporting
- Uses the existing logger infrastructure (`@cappa/logger`) for consistency
- No changes to the capture logic itself; this is purely informational feedback

https://claude.ai/code/session_0133cFyK5VGsCanCyUb5xibx