### PR TITLE
perf(core): eliminate redundant PNG decodes and temp-file round-trips in image comparison

### DIFF
--- a/.changeset/perf-compare-hot-path.md
+++ b/.changeset/perf-compare-hot-path.md
@@ -1,0 +1,10 @@
+---
+"@cappa/core": patch
+---
+
+perf(core): eliminate redundant PNG decodes and temp-file round-trips in image comparison
+
+- Pass expected-image file path directly to the native comparator instead of reading into a Buffer and writing back to a temp file
+- Replace full sharp decode for PNG validation with an 8-byte signature check
+- Extract image dimensions from the 24-byte IHDR header instead of a full sharp decode
+- Inject diff metadata directly into the PNG buffer instead of decode/set/re-encode

--- a/packages/core/src/compare/pixel.test.ts
+++ b/packages/core/src/compare/pixel.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { PNG as CappaPNG } from "../features/png/png";
 import {
   type CompareOptions,
@@ -398,6 +399,39 @@ describe("compare", () => {
 
       expect(result.passed).toBe(true);
       expect(result.percentDifference).toBe(0);
+    });
+  });
+
+  describe("performance optimizations", () => {
+    it("should not write temp files when both inputs are paths", async () => {
+      const writeSpy = vi.spyOn(fsp, "writeFile");
+      const redPath = path.join(testDir, "red.png");
+      const bluePath = path.join(testDir, "blue.png");
+
+      await compareImages(redPath, bluePath);
+
+      expect(writeSpy).not.toHaveBeenCalled();
+      writeSpy.mockRestore();
+    });
+
+    it("should not call PNG.load for dimension extraction", async () => {
+      const loadSpy = vi.spyOn(CappaPNG, "load");
+      const redPath = path.join(testDir, "red.png");
+      const bluePath = path.join(testDir, "blue.png");
+
+      await compareImages(redPath, bluePath);
+
+      expect(loadSpy).not.toHaveBeenCalled();
+      loadSpy.mockRestore();
+    });
+
+    it("should reject invalid PNG buffers with a clear error", async () => {
+      const invalidBuffer = Buffer.from("not a png file");
+      const validImage = await createSolidColorPNG(50, 50, [255, 0, 0, 255]);
+
+      await expect(compareImages(invalidBuffer, validImage)).rejects.toThrow(
+        "Invalid PNG buffer",
+      );
     });
   });
 });

--- a/packages/core/src/compare/pixel.ts
+++ b/packages/core/src/compare/pixel.ts
@@ -10,6 +10,11 @@ import {
 } from "@blazediff/core-native";
 import { getLogger } from "@cappa/logger";
 import { PNG } from "../features/png/png";
+import {
+  injectTextMetadata,
+  isValidPngSignature,
+  readIhdrDimensions,
+} from "../features/png/util";
 import type { DiffConfig } from "../types";
 
 /** Pixel diff options: Cappa `DiffConfig` plus optional native-only output tuning. */
@@ -46,7 +51,10 @@ async function resolveInputPath(
     return path.resolve(source);
   }
 
-  await PNG.load(source);
+  if (!isValidPngSignature(source)) {
+    throw new Error("Invalid PNG buffer: missing PNG signature");
+  }
+
   const root = await ensureTempRoot(state);
   const dest = path.join(root, fileName);
   await fsp.writeFile(dest, source);
@@ -146,7 +154,7 @@ export async function compareImages(
       }
     }
 
-    const { width, height } = await PNG.load(p1);
+    const { width, height } = await readIhdrDimensions(p1);
     const totalPixels = width * height;
 
     if (nativeResult.match) {
@@ -162,9 +170,16 @@ export async function compareImages(
 
     let diffBuffer: Buffer | undefined;
     if (withDiff && diffPath) {
-      const raw = await fsp.readFile(diffPath);
-      const diffPng = await PNG.load(raw);
-      diffBuffer = await annotateDiffImage(diffPng, options).toBuffer();
+      const rawDiff = await fsp.readFile(diffPath);
+      const diffMetadata: Record<string, string> = {
+        "cappa.diff.algorithm": "pixel",
+      };
+      for (const [key, value] of Object.entries(options)) {
+        if (value !== undefined) {
+          diffMetadata[`cappa.diff.${key}`] = String(value);
+        }
+      }
+      diffBuffer = injectTextMetadata(rawDiff, diffMetadata);
     }
 
     const numDiffPixels = nativeResult.diffCount;
@@ -188,20 +203,6 @@ export async function compareImages(
         });
     }
   }
-}
-
-function annotateDiffImage(image: PNG, options: DiffConfig) {
-  image.setMetadata("cappa.diff.algorithm", "pixel");
-
-  for (const [key, value] of Object.entries(options)) {
-    if (value === undefined) {
-      continue;
-    }
-
-    image.setMetadata(`cappa.diff.${key}`, String(value));
-  }
-
-  return image;
 }
 
 /**

--- a/packages/core/src/features/png/util.test.ts
+++ b/packages/core/src/features/png/util.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PNG as CappaPNG } from "./png";
+import { isValidPngSignature, readIhdrDimensions } from "./util";
+
+describe("isValidPngSignature", () => {
+  it("should return true for a valid PNG buffer", async () => {
+    const png = await CappaPNG.create(10, 10).toBuffer();
+    expect(isValidPngSignature(png)).toBe(true);
+  });
+
+  it("should return false for a non-PNG buffer", () => {
+    expect(isValidPngSignature(Buffer.from("not a png"))).toBe(false);
+  });
+
+  it("should return false for a buffer shorter than 8 bytes", () => {
+    expect(isValidPngSignature(Buffer.from([0x89, 0x50]))).toBe(false);
+  });
+
+  it("should return false for an empty buffer", () => {
+    expect(isValidPngSignature(Buffer.alloc(0))).toBe(false);
+  });
+});
+
+describe("readIhdrDimensions", () => {
+  const testDir = path.join(os.tmpdir(), "cappa-util-test-");
+  let tempDir: string;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(testDir);
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should read dimensions from a PNG buffer", async () => {
+    const buf = await CappaPNG.create(123, 456).toBuffer();
+    const { width, height } = await readIhdrDimensions(buf);
+    expect(width).toBe(123);
+    expect(height).toBe(456);
+  });
+
+  it("should read dimensions from a PNG file path", async () => {
+    const buf = await CappaPNG.create(320, 240).toBuffer();
+    const filePath = path.join(tempDir, "dims.png");
+    fs.writeFileSync(filePath, buf);
+
+    const { width, height } = await readIhdrDimensions(filePath);
+    expect(width).toBe(320);
+    expect(height).toBe(240);
+  });
+
+  it("should throw for a non-PNG buffer", async () => {
+    await expect(readIhdrDimensions(Buffer.from("not a png"))).rejects.toThrow(
+      "Not a valid PNG",
+    );
+  });
+
+  it("should throw for a buffer smaller than 24 bytes", async () => {
+    await expect(readIhdrDimensions(Buffer.alloc(10))).rejects.toThrow(
+      "Not a valid PNG",
+    );
+  });
+});

--- a/packages/core/src/features/png/util.ts
+++ b/packages/core/src/features/png/util.ts
@@ -1,3 +1,4 @@
+import { open } from "node:fs/promises";
 import type { MetadataEntries } from "./types";
 
 type ParsedChunk = {
@@ -130,6 +131,42 @@ export function injectTextMetadata(buffer: Buffer, metadata: MetadataEntries) {
     ...textChunks,
     buffer.subarray(iendChunk.offset),
   ]);
+}
+
+export function isValidPngSignature(buffer: Buffer): boolean {
+  if (buffer.length < pngSignature.length) return false;
+  return buffer.subarray(0, pngSignature.length).equals(pngSignature);
+}
+
+const IHDR_MIN_BYTES = 24;
+
+export async function readIhdrDimensions(
+  source: string | Buffer,
+): Promise<{ width: number; height: number }> {
+  let buf: Buffer;
+
+  if (typeof source === "string") {
+    const fh = await open(source, "r");
+    try {
+      buf = Buffer.alloc(IHDR_MIN_BYTES);
+      await fh.read(buf, 0, IHDR_MIN_BYTES, 0);
+    } finally {
+      await fh.close();
+    }
+  } else {
+    buf = source;
+  }
+
+  if (
+    buf.length < IHDR_MIN_BYTES ||
+    !buf.subarray(0, pngSignature.length).equals(pngSignature)
+  ) {
+    throw new Error("Not a valid PNG");
+  }
+
+  const width = buf.readUInt32BE(16);
+  const height = buf.readUInt32BE(20);
+  return { width, height };
 }
 
 /**

--- a/packages/core/src/screenshot.ts
+++ b/packages/core/src/screenshot.ts
@@ -406,7 +406,7 @@ class ScreenshotTool {
   async takeScreenshotWithComparison(
     page: Page,
     filename: string,
-    referenceImage: Buffer,
+    referenceImage: string | Buffer,
     options: ScreenshotSettings & {
       saveDiffImage?: boolean;
       diffImageFilename?: string;
@@ -524,7 +524,7 @@ class ScreenshotTool {
 
   async retryScreenshot(
     page: Page,
-    referenceImage: Buffer,
+    referenceImage: string | Buffer,
     options: ScreenshotSettings,
     diffOverride?: DiffOptions,
   ) {
@@ -656,7 +656,7 @@ class ScreenshotTool {
         await this.takeScreenshotWithComparison(
           page,
           filename,
-          await this.filesystem.readExpectedFile(filename),
+          this.filesystem.getExpectedFilePath(filename),
           {
             ...options,
             saveDiffImage: saveDiff,


### PR DESCRIPTION
- Pass expected-image file path directly to native comparator instead of
  reading into Buffer and writing back to a temp file
- Replace full sharp decode for PNG validation with 8-byte signature check
- Extract image dimensions from 24-byte IHDR header instead of full decode
- Inject diff metadata directly into PNG buffer instead of decode/set/re-encode
- Remove annotateDiffImage helper (replaced by direct injectTextMetadata)
- Add isValidPngSignature and readIhdrDimensions utilities with tests
- Add performance optimization tests verifying no temp files or PNG.load
  calls when path inputs are used

Closes #261

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016WNpja6RZZq67X83Uf7xzb