### PR TITLE
perf(cli): replace static pre-chunking with work-stealing pool in capture

### DIFF
--- a/.changeset/capture-work-stealing-pool.md
+++ b/.changeset/capture-work-stealing-pool.md
@@ -1,0 +1,11 @@
+---
+"@cappa/core": patch
+"@cappa/cli": patch
+---
+
+perf(cli): replace static pre-chunking with work-stealing pool in capture
+
+Replace fixed chunk assignment with a shared work queue so pages grab the
+next task as soon as they finish the current one. Reuses and extends the
+existing `mapWithConcurrency` utility from `@cappa/core` to support return
+values and worker indices. Eliminates idle tail time when task durations vary.

--- a/packages/cli/src/commands/capture.ts
+++ b/packages/cli/src/commands/capture.ts
@@ -2,6 +2,7 @@ import { glob } from "node:fs/promises";
 import path from "node:path";
 import {
   type FailedScreenshot,
+  mapWithConcurrency,
   ScreenshotFileSystem,
   ScreenshotTool,
 } from "@cappa/core";
@@ -303,69 +304,55 @@ const runCapture = async (options: CaptureOptions = {}): Promise<void> => {
 
       anyTasksRan = true;
       let pluginHasFailure = false;
-      // Phase 2: Execute tasks in parallel chunks
-      // Use the minimum of concurrency and actual number of tasks to avoid empty chunks
-      const effectiveConcurrency = Math.min(
-        tasks.length,
-        screenshotTool.concurrency,
-      );
-      const chunkSize = Math.ceil(tasks.length / effectiveConcurrency);
-      const chunks: (typeof tasks)[] = [];
-
-      for (let i = 0; i < tasks.length; i += chunkSize) {
-        chunks.push(tasks.slice(i, i + chunkSize));
-      }
 
       logger.debug(
-        `Processing ${tasks.length} tasks with ${effectiveConcurrency} contexts in ${chunks.length} chunks`,
+        `Processing ${tasks.length} tasks with concurrency ${screenshotTool.concurrency}`,
       );
 
       let completedTasks = 0;
+      const pageContexts = new Map<number, any>();
 
-      const allResults = await Promise.all(
-        chunks.map(async (chunk, chunkIndex) => {
-          const page = screenshotTool.getPageFromPool(chunkIndex);
-          const chunkResults: Array<{
-            result: PluginCaptureResult;
-            task: (typeof tasks)[number];
-          }> = [];
-          let context: any;
+      const allResults = await mapWithConcurrency(
+        screenshotTool.concurrency,
+        tasks,
+        async (task: any, workerIndex) => {
+          const page = screenshotTool.getPageFromPool(workerIndex);
 
-          // Initialize page if plugin has initPage method
-          if (plugin.initPage) {
-            context = await plugin.initPage(page, screenshotTool);
-          }
-
-          for (const task of chunk) {
-            logger.debug(`Executing task: ${task.id}`);
-            const result = await plugin.execute(
-              task,
-              page,
-              screenshotTool,
-              context,
+          if (!pageContexts.has(workerIndex) && plugin.initPage) {
+            pageContexts.set(
+              workerIndex,
+              await plugin.initPage(page, screenshotTool),
             );
-            chunkResults.push({ result, task });
+          }
+          const context = pageContexts.get(workerIndex);
 
-            completedTasks++;
-            logger.info(formatProgress(completedTasks, tasks.length, task.id));
+          logger.debug(`Executing task: ${task.id}`);
+          const result = await plugin.execute(
+            task,
+            page,
+            screenshotTool,
+            context,
+          );
 
-            if (didScreenshotFail(result)) {
-              pluginHasFailure = true;
-              hasScreenshotFailure = true;
-              failedScreenshots.push({
-                taskId: task.id,
-                taskUrl: task.url,
-                result: result as PluginCaptureResult,
-                pluginName: plugin.name,
-              });
-            }
+          completedTasks++;
+          logger.info(formatProgress(completedTasks, tasks.length, task.id));
+
+          if (didScreenshotFail(result)) {
+            pluginHasFailure = true;
+            hasScreenshotFailure = true;
+            failedScreenshots.push({
+              taskId: task.id,
+              taskUrl: task.url,
+              result: result as PluginCaptureResult,
+              pluginName: plugin.name,
+            });
           }
 
-          return chunkResults;
-        }),
+          return result;
+        },
       );
 
-      const results = allResults.flat().map((r) => r.result);
+      const results = allResults;
       if (pluginHasFailure) {
         logger.error(
           `Plugin ${plugin.name} completed with failures: ${results.length} results`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ import {
   ScreenshotFileSystem,
   toDiffMetaPath,
 } from "./filesystem";
+import { mapWithConcurrency } from "./mapWithConcurrency";
 import type { Plugin, PluginDef, PluginFunction } from "./plugin";
 import ScreenshotTool, {
   type ScreenshotCaptureDetails,
@@ -54,6 +55,7 @@ export {
   type InterpretResult,
   imagesMatch,
   imagesMatchGMSD,
+  mapWithConcurrency,
   type NewScreenshot,
   type PassedScreenshot,
   type Plugin,

--- a/packages/core/src/mapWithConcurrency.test.ts
+++ b/packages/core/src/mapWithConcurrency.test.ts
@@ -24,7 +24,64 @@ describe("mapWithConcurrency", () => {
 
   it("no-ops on empty items", async () => {
     const fn = vi.fn();
-    await mapWithConcurrency(4, [], fn);
+    const results = await mapWithConcurrency(4, [], fn);
     expect(fn).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it("returns results in input order regardless of completion order", async () => {
+    const delays = [30, 10, 20];
+    const results = await mapWithConcurrency(3, delays, async (delay) => {
+      await new Promise((r) => setTimeout(r, delay));
+      return delay * 2;
+    });
+
+    expect(results).toEqual([60, 20, 40]);
+  });
+
+  it("passes a stable workerIndex to each callback invocation", async () => {
+    const workerCalls = new Map<number, number[]>();
+
+    await mapWithConcurrency(
+      2,
+      [1, 2, 3, 4, 5, 6],
+      async (item, workerIndex) => {
+        const calls = workerCalls.get(workerIndex) ?? [];
+        calls.push(item);
+        workerCalls.set(workerIndex, calls);
+        await new Promise((r) => setTimeout(r, 0));
+      },
+    );
+
+    expect(workerCalls.size).toBeLessThanOrEqual(2);
+    for (const [idx] of workerCalls) {
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(2);
+    }
+    const allItems = [...workerCalls.values()].flat().sort((a, b) => a - b);
+    expect(allItems).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("distributes work dynamically so fast workers pick up more tasks", async () => {
+    const workerTaskCounts = new Map<number, number>();
+
+    await mapWithConcurrency(
+      2,
+      [1, 2, 3, 4, 5, 6, 7, 8],
+      async (item, workerIndex) => {
+        workerTaskCounts.set(
+          workerIndex,
+          (workerTaskCounts.get(workerIndex) ?? 0) + 1,
+        );
+        const delay = item <= 4 ? 50 : 5;
+        await new Promise((r) => setTimeout(r, delay));
+      },
+    );
+
+    const worker0 = workerTaskCounts.get(0) ?? 0;
+    const worker1 = workerTaskCounts.get(1) ?? 0;
+    expect(worker0 + worker1).toBe(8);
+    expect(worker0).toBeGreaterThan(0);
+    expect(worker1).toBeGreaterThan(0);
   });
 });

--- a/packages/core/src/mapWithConcurrency.ts
+++ b/packages/core/src/mapWithConcurrency.ts
@@ -1,21 +1,23 @@
 /**
  * Run async work over `items` with at most `concurrency` tasks in flight.
  * Preserves failure behavior: the first rejection rejects the returned promise.
+ * Results are returned in the same order as the input items.
  */
-export async function mapWithConcurrency<T>(
+export async function mapWithConcurrency<T, R = void>(
   concurrency: number,
   items: readonly T[],
-  fn: (item: T) => Promise<void>,
-): Promise<void> {
+  fn: (item: T, workerIndex: number) => Promise<R>,
+): Promise<R[]> {
   if (items.length === 0) {
-    return;
+    return [];
   }
 
   const limit = Math.max(1, concurrency);
   const workerCount = Math.min(limit, items.length);
+  const results: R[] = new Array(items.length);
   let next = 0;
 
-  const worker = async (): Promise<void> => {
+  const worker = async (workerIndex: number): Promise<void> => {
     while (true) {
       const i = next++;
       if (i >= items.length) {
@@ -25,9 +27,11 @@ export async function mapWithConcurrency<T>(
       if (item === undefined) {
         return;
       }
-      await fn(item);
+      results[i] = await fn(item, workerIndex);
     }
   };
 
-  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  await Promise.all(Array.from({ length: workerCount }, (_, i) => worker(i)));
+
+  return results;
 }


### PR DESCRIPTION
Replace fixed chunk assignment with a shared work queue so pages grab the
next task as soon as they finish the current one. Extends mapWithConcurrency
to support return values and worker indices, and exports it from @cappa/core.

Fixes #264

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BcvdF4TpDgyePbJidaGt5T