### PR TITLE
fix(plugin-storybook): normalize story filenames to lowercase

### DIFF
--- a/.changeset/storybook-title-normalization.md
+++ b/.changeset/storybook-title-normalization.md
@@ -1,0 +1,5 @@
+---
+"@cappa/plugin-storybook": patch
+---
+
+Normalize story filenames to lowercase to prevent case-sensitivity mismatches between local (macOS, case-insensitive) and CI/Docker (Linux, case-sensitive) environments

--- a/packages/plugins/plugin-storybook/src/cappa/util.test.ts
+++ b/packages/plugins/plugin-storybook/src/cappa/util.test.ts
@@ -2,46 +2,82 @@ import { describe, expect, it } from "vitest";
 import type { StorybookStory } from "./plugin";
 import { buildFilename } from "./util";
 
+const makeStory = (
+  overrides: Partial<StorybookStory> = {},
+): StorybookStory => ({
+  id: "1",
+  name: "Primary",
+  title: "Story",
+  kind: "Kind",
+  story: "Story",
+  type: "story",
+  ...overrides,
+});
+
 describe("buildFilename", () => {
   it("should build a filename for a story", () => {
-    const story: StorybookStory = {
-      id: "1",
-      name: "Primary",
-      title: "Story",
-      kind: "Kind",
-      story: "Story",
-      type: "story",
-    };
-
-    const filename = buildFilename(story);
-    expect(filename).toBe("Story/Primary.png");
+    const filename = buildFilename(makeStory());
+    expect(filename).toBe("story/primary.png");
   });
 
   it("should build a filename for a story with a folder", () => {
-    const story: StorybookStory = {
-      id: "1",
-      name: "Primary",
-      title: "Folder/Story",
-      kind: "Kind",
-      story: "Story",
-      type: "story",
-    };
-
-    const filename = buildFilename(story);
-    expect(filename).toBe("Folder/Story/Primary.png");
+    const filename = buildFilename(
+      makeStory({ title: "Folder/Story", name: "Primary" }),
+    );
+    expect(filename).toBe("folder/story/primary.png");
   });
 
   it("should build a filename for a story with special characters", () => {
-    const story: StorybookStory = {
-      id: "1",
-      name: "Primary123!@#$%^&*()",
-      title: "Story123!@#$%^&*()",
-      kind: "Kind",
-      story: "Story",
-      type: "story",
-    };
+    const filename = buildFilename(
+      makeStory({
+        title: "Story123!@#$%^&*()",
+        name: "Primary123!@#$%^&*()",
+      }),
+    );
+    expect(filename).toBe("story123/primary123.png");
+  });
 
-    const filename = buildFilename(story);
-    expect(filename).toBe("Story123/Primary123.png");
+  it("should normalize case to lowercase", () => {
+    const filename = buildFilename(
+      makeStory({
+        title: "features/keys/pages/Create/components/ValueTypeChangeDialog",
+        name: "Default",
+      }),
+    );
+    expect(filename).toBe(
+      "features/keys/pages/create/components/valuetypechangedialog/default.png",
+    );
+  });
+
+  it("should produce the same filename regardless of title casing", () => {
+    const upper = buildFilename(
+      makeStory({
+        title: "features/keys/pages/Create/components/ValueTypeChangeDialog",
+        name: "Default",
+      }),
+    );
+    const lower = buildFilename(
+      makeStory({
+        title: "features/keys/pages/create/components/valuetypechangedialog",
+        name: "Default",
+      }),
+    );
+    expect(upper).toBe(lower);
+  });
+
+  it("should strip hyphens so kebab-case and camelCase produce the same filename", () => {
+    const kebab = buildFilename(
+      makeStory({
+        title: "components/value-type-change-dialog",
+        name: "Default",
+      }),
+    );
+    const camel = buildFilename(
+      makeStory({
+        title: "components/ValueTypeChangeDialog",
+        name: "Default",
+      }),
+    );
+    expect(kebab).toBe(camel);
   });
 });

--- a/packages/plugins/plugin-storybook/src/cappa/util.ts
+++ b/packages/plugins/plugin-storybook/src/cappa/util.ts
@@ -96,5 +96,7 @@ export const waitForVisualIdle = async (page: Page) => {
  * @returns The filename for the story. Slashes represent folders that should be handled by seperate file system calls.
  */
 export const buildFilename = (story: StorybookStory) => {
-  return `${story.title.replace(/[^a-zA-Z0-9/]/g, "")}/${story.name.replace(/[^a-zA-Z0-9]/g, "")}.png`;
+  const title = story.title.replace(/[^a-zA-Z0-9/]/g, "").toLowerCase();
+  const name = story.name.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+  return `${title}/${name}.png`;
 };


### PR DESCRIPTION
## What changed

`buildFilename` in `@cappa/plugin-storybook` now normalizes all screenshot filenames to lowercase. Previously, the casing of directory and file segments was preserved exactly as Storybook reported them in its `index.json`.

## Why

Storybook derives story titles from file paths when no explicit `title` is set (auto-title). The casing and formatting of these auto-generated titles is not stable across Storybook versions — for example, a directory named `Create` might appear as `Create` in one version and `create` in another, or `ValueTypeChangeDialog` might become `value-type-change-dialog`. Since cappa uses the title to build the screenshot file path, any change in casing causes cappa to treat the screenshot as deleted and recreated, producing false "new" and "deleted" results.

This is especially problematic in CI environments running Linux (case-sensitive filesystem), where `Create/` and `create/` are different directories. On macOS (case-insensitive filesystem), the mismatch is silently ignored — which is why the issue only surfaces in Docker/CI but not locally.

Lowercasing the entire filename makes it deterministic regardless of how Storybook formats the title.

## Notice for consumers

This is a breaking change for existing baselines. After upgrading, all screenshot paths will shift to lowercase (e.g. `MyComponent/Default.png` becomes `mycomponent/default.png`). You will need to run `cappa approve` once to re-establish baselines under the new names. The old mixed-case files in `expected/` can be deleted after approval.

## Test plan

- [x] Updated `buildFilename` tests to expect lowercase output
- [x] Added test: same filename regardless of title casing
- [x] Added test: kebab-case and camelCase titles produce the same filename
- [x] All 35 plugin-storybook tests pass
- [x] All core, cli, logger tests pass
- [x] Lint and type-check clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgkNmhAbwb3vebXyH918eo)_