### PR TITLE
Add --filter option to capture command for selective task execution

### DIFF
--- a/.changeset/capture-filter-option.md
+++ b/.changeset/capture-filter-option.md
@@ -1,0 +1,6 @@
+---
+"@cappa/cli": minor
+"@cappa/core": patch
+---
+
+Add `--filter` / `-f` option to the `capture` command to filter tasks by id using a glob pattern. Also exports the `PluginTask` type from `@cappa/core`.

--- a/apps/docs/src/content/docs/cli.mdx
+++ b/apps/docs/src/content/docs/cli.mdx
@@ -23,6 +23,21 @@ cappa capture
 Cappa also enables the same CI mode automatically when `CI=true` is set in the environment, so
 `cappa capture` behaves like `cappa capture --ci` in most CI/CD pipelines.
 
+Use `--filter` (or `-f`) to capture only tasks whose id matches a glob pattern. This is useful
+when you want to iterate on a single component without re-capturing everything. The pattern is
+matched against each task's id using Node's built-in glob matching.
+
+```bash
+# capture only button stories
+cappa capture --filter "button*"
+
+# capture a single story by exact id
+cappa capture -f "card--default"
+```
+
+When a filter is active, Cappa displays a hint box and logs how many tasks matched per plugin so
+you can verify the pattern is selecting what you expect.
+
 ## `cappa review`
 
 Launches an interface for comparing the latest screenshots against the approved baseline. The review

--- a/packages/cli/src/commands/capture.test.ts
+++ b/packages/cli/src/commands/capture.test.ts
@@ -2,6 +2,7 @@ import type { ScreenshotTool } from "@cappa/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   didScreenshotFail,
+  filterTasks,
   formatDuration,
   formatProgress,
   getDeletedScreenshots,
@@ -185,5 +186,43 @@ describe("formatDuration", () => {
     expect(formatDuration(60000)).toBe("1m 0s");
     expect(formatDuration(90000)).toBe("1m 30s");
     expect(formatDuration(125000)).toBe("2m 5s");
+  });
+});
+
+describe("filterTasks", () => {
+  const tasks = [
+    { id: "button--primary", url: "http://localhost:6006" },
+    { id: "button--secondary", url: "http://localhost:6006" },
+    { id: "card--default", url: "http://localhost:6006" },
+    { id: "card--with-image", url: "http://localhost:6006" },
+    { id: "header--logged-in", url: "http://localhost:6006" },
+  ];
+
+  it("filters tasks matching a glob pattern with wildcard", () => {
+    const result = filterTasks(tasks, "button*");
+    expect(result.map((t) => t.id)).toEqual([
+      "button--primary",
+      "button--secondary",
+    ]);
+  });
+
+  it("filters tasks matching an exact id", () => {
+    const result = filterTasks(tasks, "card--default");
+    expect(result.map((t) => t.id)).toEqual(["card--default"]);
+  });
+
+  it("returns empty array when no tasks match", () => {
+    const result = filterTasks(tasks, "footer*");
+    expect(result).toEqual([]);
+  });
+
+  it("returns all tasks when pattern matches everything", () => {
+    const result = filterTasks(tasks, "*");
+    expect(result).toHaveLength(5);
+  });
+
+  it("supports character class patterns", () => {
+    const result = filterTasks(tasks, "card--*image");
+    expect(result.map((t) => t.id)).toEqual(["card--with-image"]);
   });
 });

--- a/packages/cli/src/commands/capture.ts
+++ b/packages/cli/src/commands/capture.ts
@@ -1,5 +1,6 @@
 import { glob } from "node:fs/promises";
 import path from "node:path";
+import type { PluginTask } from "@cappa/core";
 import {
   type FailedScreenshot,
   mapWithConcurrency,
@@ -233,7 +234,12 @@ export async function getDeletedScreenshots(
 
 type CaptureOptions = {
   ci?: boolean;
+  filter?: string;
 };
+
+export function filterTasks(tasks: PluginTask[], filter: string): PluginTask[] {
+  return tasks.filter((task) => path.matchesGlob(task.id, filter));
+}
 
 export function registerSignalHandlers(
   screenshotTool: ScreenshotTool,
@@ -296,6 +302,21 @@ const runCapture = async (options: CaptureOptions = {}): Promise<void> => {
         return { plugin, tasks };
       }),
     );
+
+    if (options.filter) {
+      logger.box({
+        title: "Filter Active",
+        message: `Only capturing tasks matching: ${chalk.cyan(options.filter)}`,
+      });
+
+      for (const entry of pluginTasks) {
+        const before = entry.tasks.length;
+        entry.tasks = filterTasks(entry.tasks, options.filter);
+        logger.info(
+          `${entry.plugin.name}: ${entry.tasks.length}/${before} tasks match filter`,
+        );
+      }
+    }
 
     for (const { plugin, tasks } of pluginTasks) {
       if (tasks.length === 0) {
@@ -415,6 +436,10 @@ export const registerCaptureCommand = (program: Command): void => {
     .command("capture")
     .description("Capture screenshots")
     .option("--ci", "run capture in CI mode and execute onFail callback")
+    .option(
+      "-f, --filter <pattern>",
+      "only capture tasks whose id matches the given glob pattern",
+    )
     .action(async (options: CaptureOptions) => {
       await runCapture(options);
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ import {
   toDiffMetaPath,
 } from "./filesystem";
 import { mapWithConcurrency } from "./mapWithConcurrency";
-import type { Plugin, PluginDef, PluginFunction } from "./plugin";
+import type { Plugin, PluginDef, PluginFunction, PluginTask } from "./plugin";
 import ScreenshotTool, {
   type ScreenshotCaptureDetails,
   type ScreenshotCaptureExtras,
@@ -61,6 +61,7 @@ export {
   type Plugin,
   type PluginDef,
   type PluginFunction,
+  type PluginTask,
   readDiffMeta,
   type Screenshot,
   type ScreenshotCaptureDetails,


### PR DESCRIPTION
## Summary
Adds a `--filter` (or `-f`) option to the `cappa capture` command that allows users to selectively capture only tasks whose id matches a given glob pattern. This is useful when iterating on specific components without re-capturing the entire suite.

## Changes
- **New `filterTasks` function** in `packages/cli/src/commands/capture.ts` that filters tasks using Node's built-in glob matching against task ids
- **CLI option** `--filter <pattern>` added to the capture command via commander
- **Filter application logic** in `runCapture` that:
  - Displays a hint box when a filter is active
  - Logs per-plugin task counts (matched vs. total) for verification
  - Applies the filter to all plugin tasks before execution
- **Documentation** in `apps/docs/src/content/docs/cli.mdx` with usage examples
- **Type export** of `PluginTask` from `@cappa/core/src/index.ts` to support the filter function's public API
- **Comprehensive test suite** in `packages/cli/src/commands/capture.test.ts` covering:
  - Wildcard patterns (`button*`)
  - Exact id matching
  - No matches (empty result)
  - Match-all patterns (`*`)
  - Character class patterns (`card--*image`)

## Implementation Details
- Uses `path.matchesGlob()` for glob pattern matching, consistent with Node.js conventions
- Filter is applied after all plugins discover their tasks, before execution begins
- User feedback includes a visual hint box and per-plugin task count logging to help verify the pattern is selecting expected tasks
- The feature integrates seamlessly with existing CI mode and other capture options

https://claude.ai/code/session_01HopzKT4Uc6Yd95kBM8GK7Q